### PR TITLE
Fix secretsDir override

### DIFF
--- a/lib/load-docker-secrets.js
+++ b/lib/load-docker-secrets.js
@@ -10,21 +10,21 @@ const fs = require('fs');
 const path = require('path');
 
 module.exports = {
-  load({ secretsDir = '/run/secrets' } = {}) {
-    if (fs.existsSync(secretsDir)) {
-      const files = fs.readdirSync(secretsDir);
-
-      return files.reduce((output, file) => {
-        const fullPath = path.join(secretsDir, file);
-        const key = file;
-        const data = fs.readFileSync(fullPath, 'utf8').toString().trim();
-
-        // eslint-disable-next-line no-param-reassign
-        output[key] = data;
-        return output;
-      }, {});
+  load(secretsDir = '/run/secrets') {
+    if (!fs.existsSync(secretsDir)) {
+      return {};
     }
 
-    return {};
+    const files = fs.readdirSync(secretsDir);
+
+    return files.reduce((output, file) => {
+      const fullPath = path.join(secretsDir, file);
+      const key = file;
+      const data = fs.readFileSync(fullPath, 'utf8').toString().trim();
+
+      // eslint-disable-next-line no-param-reassign
+      output[key] = data;
+      return output;
+    }, {});
   },
 };


### PR DESCRIPTION
The `docker-secrets` module--which used this module--was passing in a single string argument to the `load()` function. That didn't work, since load() was expecting an object.

Since there's only one argument, I changed it to expect a simple string, which fixes the underlying problem.

I also did some minor refactoring to reduce nesting and make the code a bit more readable (in my opinion).